### PR TITLE
Exported event type

### DIFF
--- a/src/machinery.erl
+++ b/src/machinery.erl
@@ -45,6 +45,7 @@
 -export_type([args/1]).
 -export_type([response/1]).
 -export_type([machine/2]).
+-export_type([event/1]).
 
 -type modopts(O) :: module() | {module(), O}.
 


### PR DESCRIPTION
fistful-server [использует `machinery:event/1`](https://github.com/rbkmoney/fistful-server/blob/master/apps/machinery_extra/src/machinery_mg_eventsink.erl#L23), но тип не экспортирован отсюда.