### PR TITLE
Generalize repair response interface

### DIFF
--- a/src/machinery.erl
+++ b/src/machinery.erl
@@ -116,7 +116,7 @@
     result(E, A).
 
 -callback process_repair(args(_), machine(E, A), handler_args(_), handler_opts(_)) ->
-    {ok, response(_), result(E, A)} | {error, error(_)}.
+    {ok, {response(_), result(E, A)}} | {error, error(_)}.
 
 -callback process_timeout(machine(E, A), handler_args(_), handler_opts(_)) ->
     result(E, A).
@@ -149,7 +149,7 @@ repair(NS, Ref, Args, Backend) ->
     repair(NS, Ref, {undefined, undefined, forward}, Args, Backend).
 
 -spec repair(namespace(), ref(), range(), args(_), backend(_)) ->
-    {ok, response(_)} | {error, notfound | working}.
+    {ok, response(_)} | {error, notfound | working | {failed, machinery:error(_)}}.
 repair(NS, Ref, Range, Args, Backend) ->
     {Module, Opts} = machinery_utils:get_backend(Backend),
     machinery_backend:repair(Module, NS, Ref, Range, Args, Opts).
@@ -173,7 +173,7 @@ dispatch_signal({init, Args}, Machine, {Handler, HandlerArgs}, Opts) ->
     Handler:init(Args, Machine, HandlerArgs, Opts);
 dispatch_signal({repair, Args}, Machine, {Handler, HandlerArgs}, Opts) ->
     case Handler:process_repair(Args, Machine, HandlerArgs, Opts) of
-        {ok, _Response, Result} ->
+        {ok, {_Response, Result}} ->
             Result;
         {error, Reason} ->
             erlang:error({repair_failed, Reason})
@@ -187,6 +187,6 @@ dispatch_call(Args, Machine, {Handler, HandlerArgs}, Opts) ->
     Handler:process_call(Args, Machine, HandlerArgs, Opts).
 
 -spec dispatch_repair(args(_), machine(E, A), logic_handler(_), handler_opts(_)) ->
-    {ok, response(_), result(E, A)} | {error, error(_)}.
+    {ok, {response(_), result(E, A)}} | {error, error(_)}.
 dispatch_repair(Args, Machine, {Handler, HandlerArgs}, Opts) ->
     Handler:process_repair(Args, Machine, HandlerArgs, Opts).

--- a/src/machinery_mg_backend.erl
+++ b/src/machinery_mg_backend.erl
@@ -221,7 +221,7 @@ handle_function('ProcessRepair', FunctionArgs, WoodyCtx, Opts) ->
         get_handler_opts(WoodyCtx)
     ),
     case RepairResult of
-        {ok, Response, Result} ->
+        {ok, {Response, Result}} ->
             {ok, marshal({repair_result, Schema}, {Response, handle_result(Result, Machine1)})};
         {error, Reason} ->
             erlang:throw(marshal({repair_fail, Schema}, Reason))

--- a/test/machinery_repair_SUITE.erl
+++ b/test/machinery_repair_SUITE.erl
@@ -180,13 +180,13 @@ process_call(fail, _Machine, _, _Opts) ->
     erlang:error(fail).
 
 -spec process_repair(_Args, machine(), undefined, handler_opts()) ->
-    {ok, response(), result()} | {error, error()}.
+    {ok, {response(), result()}} | {error, error()}.
 process_repair(simple, _Machine, _, _Opts) ->
-    {ok, done, #{}};
+    {ok, {done, #{}}};
 process_repair({add_events, Events}, _Machine, _, _Opts) ->
-    {ok, done, #{events => Events}};
+    {ok, {done, #{events => Events}}};
 process_repair(count_events, #{history := History}, _, _Opts) ->
-    {ok, done, #{events => [{count_events, erlang:length(History)}]}};
+    {ok, {done, #{events => [{count_events, erlang:length(History)}]}}};
 process_repair(fail, _Machine, _, _Opts) ->
     {error, fail};
 process_repair(unexpected_fail, _Machine, _, _Opts) ->


### PR DESCRIPTION
Use `{ok, Success}` instead of `{ok, Response, Result}`